### PR TITLE
Update OpenSSL to 3.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/alpine:3 AS fetch-openssl
 WORKDIR /tmp/openssl
-ARG OPENSSL_VERSION="3.5.4"
-ADD --checksum=sha256:967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99 https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
+ARG OPENSSL_VERSION="3.5.5"
+ADD --checksum=sha256:b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89 https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
 RUN tar -xzvf /tmp/openssl.tar.gz --strip-components=1
 
 FROM docker.io/alpine:3 AS fetch-pcre


### PR DESCRIPTION
Security patch release fixing multiple CVEs including:
- CVE-2025-11187: Improper validation of PBMAC1 parameters
- CVE-2025-15467: Stack buffer overflow in CMS AuthEnvelopedData
- CVE-2025-15468: NULL dereference in SSL_CIPHER_find()
- CVE-2025-66199: TLS 1.3 CompressedCertificate excessive memory allocation
- CVE-2025-68160: Heap out-of-bounds write in BIO_f_linebuffer
- CVE-2026-22795: Missing ASN1_TYPE validation in PKCS#12
- CVE-2026-22796: ASN1_TYPE Type Confusion in PKCS7