### PR TITLE
bump nginx 1.28.3 → 1.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add \
       linux-headers \
       perl-dev
 WORKDIR /tmp/nginx
-ADD --checksum=sha256:2c96a946bfb0882a21744ed429770a2123ae1828c7c48665092993ddee91a918 https://nginx.org/download/nginx-1.28.3.tar.gz /tmp/nginx.tar.gz
+ADD --checksum=sha256:058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b https://nginx.org/download/nginx-1.30.0.tar.gz /tmp/nginx.tar.gz
 RUN tar -xzvf /tmp/nginx.tar.gz --strip-components=1
 COPY --from=fetch-openssl /tmp/openssl ./openssl
 COPY --from=fetch-pcre /tmp/pcre ./pcre

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 Available on Docker Hub as [`docker.io/ricardbejarano/nginx`](https://hub.docker.com/r/ricardbejarano/nginx):
 
-- [`1.28.3`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.0`, `latest` *(Dockerfile)*](Dockerfile)
 
 ### RedHat Quay
 
 Available on RedHat Quay as [`quay.io/ricardbejarano/nginx`](https://quay.io/repository/ricardbejarano/nginx):
 
-- [`1.28.3`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.0`, `latest` *(Dockerfile)*](Dockerfile)
 
 
 ## Configuration


### PR DESCRIPTION
Bumps nginx from 1.28.3 to 1.30.0 (latest stable).

Updated the SHA256 checksum accordingly (`058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b`).

No changes to dependencies (OpenSSL 3.6.2, PCRE2 10.47, zlib 1.3.2 are all already at latest).