### PR TITLE
bump nginx to 1.30.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add \
       linux-headers \
       perl-dev
 WORKDIR /tmp/nginx
-ADD --checksum=sha256:058188c64bf22baecaa72b809a6318a4f9ba623889c554feab03f7cb853ab31b https://nginx.org/download/nginx-1.30.0.tar.gz /tmp/nginx.tar.gz
+ADD --checksum=sha256:99765000d974896b31ca5882d8c279ce3fe7ef6f5c6f9f0a967ed7fd3407f9cc https://nginx.org/download/nginx-1.30.1.tar.gz /tmp/nginx.tar.gz
 RUN tar -xzvf /tmp/nginx.tar.gz --strip-components=1
 COPY --from=fetch-openssl /tmp/openssl ./openssl
 COPY --from=fetch-pcre /tmp/pcre ./pcre

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 Available on Docker Hub as [`docker.io/ricardbejarano/nginx`](https://hub.docker.com/r/ricardbejarano/nginx):
 
-- [`1.30.0`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.1`, `latest` *(Dockerfile)*](Dockerfile)
 
 ### RedHat Quay
 
 Available on RedHat Quay as [`quay.io/ricardbejarano/nginx`](https://quay.io/repository/ricardbejarano/nginx):
 
-- [`1.30.0`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.1`, `latest` *(Dockerfile)*](Dockerfile)
 
 
 ## Configuration


### PR DESCRIPTION
Bumps nginx from 1.30.0 to 1.30.1.

Updates `Dockerfile` and `README.md`.

Verified sha256 checksum against the official tarball from nginx.org.