### PR TITLE
bump openssl 4.0.0 → 4.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/alpine:3 AS fetch-openssl
 WORKDIR /tmp/openssl
-ARG OPENSSL_VERSION="4.0.0"
-ADD --checksum=sha256:c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
+ARG OPENSSL_VERSION="4.0.1"
+ADD --checksum=sha256:2db3f3a0d6ea4b59e1f094ace2c8cd536dffb87cdc39084c5afa1e6f7f37dd09 https://github.com/openssl/openssl/releases/download/openssl-$OPENSSL_VERSION/openssl-$OPENSSL_VERSION.tar.gz /tmp/openssl.tar.gz
 RUN tar -xzvf /tmp/openssl.tar.gz --strip-components=1
 
 FROM docker.io/alpine:3 AS fetch-pcre


### PR DESCRIPTION
Bumps OpenSSL from 4.0.0 to 4.0.1.

Checksum verified against the official `openssl-4.0.1.tar.gz.sha256` published with the [OpenSSL 4.0.1 release](https://github.com/openssl/openssl/releases/tag/openssl-4.0.1):

```
2db3f3a0d6ea4b59e1f094ace2c8cd536dffb87cdc39084c5afa1e6f7f37dd09  openssl-4.0.1.tar.gz
```

PCRE2 (10.47), zlib (1.3.2) and nginx (1.30.2 stable) are already at their latest releases, so no other changes are needed. The image tag is unaffected, so `README.md` needs no update.