### PR TITLE
Update nginx to 1.30.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add \
       linux-headers \
       perl-dev
 WORKDIR /tmp/nginx
-ADD --checksum=sha256:e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f https://nginx.org/download/nginx-1.30.3.tar.gz /tmp/nginx.tar.gz
+ADD --checksum=sha256:4261dc90e9e47c1c4041276e9aaa3d48ebe2e664f728e14fa95ae6c67d57a08b https://nginx.org/download/nginx-1.30.4.tar.gz /tmp/nginx.tar.gz
 RUN tar -xzvf /tmp/nginx.tar.gz --strip-components=1
 COPY --from=fetch-openssl /tmp/openssl ./openssl
 COPY --from=fetch-pcre /tmp/pcre ./pcre

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 Available on Docker Hub as [`docker.io/ricardbejarano/nginx`](https://hub.docker.com/r/ricardbejarano/nginx):
 
-- [`1.30.3`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.4`, `latest` *(Dockerfile)*](Dockerfile)
 
 ### RedHat Quay
 
 Available on RedHat Quay as [`quay.io/ricardbejarano/nginx`](https://quay.io/repository/ricardbejarano/nginx):
 
-- [`1.30.3`, `latest` *(Dockerfile)*](Dockerfile)
+- [`1.30.4`, `latest` *(Dockerfile)*](Dockerfile)
 
 
 ## Configuration


### PR DESCRIPTION
Bumps nginx from `1.30.3` to `1.30.4` (latest stable).

- Updated the `nginx` tarball URL and its `sha256` checksum in the `Dockerfile`. Checksum verified against the official `nginx.org` download: `4261dc90e9e47c1c4041276e9aaa3d48ebe2e664f728e14fa95ae6c67d57a08b`.
- Updated the tag references in `README.md`.

Bundled libraries (OpenSSL 4.0.1, PCRE2 10.47, zlib 1.3.2) are already current. HAProxy and SNMP Exporter repos were also checked and are up to date.